### PR TITLE
[fix] coments for 25-26 4th

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GDSC SKHU
+Copyright (c) 2026 GDGOC SKHU
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -23,7 +23,3 @@ yarn start
 - Emotion
 - Three.js with react-three/fiber and drei
 - Eslint, Prettier
-
-## History
-
-[릴리즈 확인하기](https://github.com/GDSC-SKHU/www.gdsc-skhu.com/releases)


### PR DESCRIPTION
LICENSE 관련 문구 최신화, 
README 미사용 릴리즈 히스토리 삭제,
누락된 파일들(Feat: 25-26 4th Member Recruit page commit 건 )에 대한 배포가 담겨져있습니다.

문구 수정 (각 페이지 소개 문구 및 https://gdg.community.dev/ 주소 수정 -> 
https://sites.google.com/view/gdeveloperskorea/gdg-on-campus) 커밋,
린트 에러 (GDG_oC_LINK -> GDG_OC_LINK 문법 수정) 및
린트 에러 (quot 문법) 보완 커밋,
https://github.com/GDG-on-Campus-SKHU/www.gdgoc-skhu.com/commit/f2654885186f52eb8b8b253e1ed3a9aba41b1f4f
https://github.com/GDG-on-Campus-SKHU/www.gdgoc-skhu.com/commit/88cf8c3d2fbfaa7a0a2194f3540224c4a9801cab
https://github.com/GDG-on-Campus-SKHU/www.gdgoc-skhu.com/commit/29774b2d2505e1fe1a58458018b6253994d32cb0


