### PR TITLE
[Feat] 4기 모집 마감에 따른 버튼 비활성화 및 릴리즈 복구

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 GDSC SKHU
+Copyright (c) 2026 GDGOC SKHU
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -23,7 +23,3 @@ yarn start
 - Emotion
 - Three.js with react-three/fiber and drei
 - Eslint, Prettier
-
-## History
-
-[릴리즈 확인하기](https://github.com/GDSC-SKHU/www.gdsc-skhu.com/releases)

--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ yarn start
 - Emotion
 - Three.js with react-three/fiber and drei
 - Eslint, Prettier
+
+## History
+
+[릴리즈 확인하기](https://github.com/GDSC-SKHU/www.gdsc-skhu.com/releases)

--- a/src/components/RecruitSection/RecruitSection.tsx
+++ b/src/components/RecruitSection/RecruitSection.tsx
@@ -51,11 +51,11 @@ export default function RecruitSection() {
           <br />
         </motion.h2>
         {/* <RecruitAnchor href={CORE_RECRUIT_LINK} text="✨ 25-26 Core 멤버 지원하기" /> */}
-        <RecruitAnchor href={PM_RECRUIT_LINK} text="🧭 PM 파트 멤버 지원하기" />
-        <RecruitAnchor href={DESIGN_RECRUIT_LINK} text="🎨 Design 파트 멤버 지원하기" />
-        <RecruitAnchor href={WEB_RECRUIT_LINK} text="🌎 Web 파트 멤버 지원하기" />
-        <RecruitAnchor href={MOBILE_RECRUIT_LINK} text="📱 Mobile 파트 멤버 지원하기" />
-        <RecruitAnchor href={SERVER_RECRUIT_LINK} text="🔧 Server 파트 멤버 지원하기" />
+        <RecruitAnchor href={PM_RECRUIT_LINK} text="🧭 PM 파트 멤버 지원하기" disable />
+        <RecruitAnchor href={DESIGN_RECRUIT_LINK} text="🎨 Design 파트 멤버 지원하기" disable />
+        <RecruitAnchor href={WEB_RECRUIT_LINK} text="🌎 Web 파트 멤버 지원하기" disable />
+        <RecruitAnchor href={MOBILE_RECRUIT_LINK} text="📱 Mobile 파트 멤버 지원하기" disable />
+        <RecruitAnchor href={SERVER_RECRUIT_LINK} text="🔧 Server 파트 멤버 지원하기" disable />
       </motion.div>
     </section>
   );
@@ -73,7 +73,7 @@ function RecruitAnchor({ href, text, disable = false }: RecruitAnchorProps) {
       <motion.button
         variants={defaultFadeInUpVariants}
         onClick={() => {
-          alert('모집 기간이 아닙니다.');
+          alert('현재 기수 모집은 마감되었습니다. 다음 기수 모집을 기다려주세요!');
         }}
         css={css`
           ${glassButtonCss}


### PR DESCRIPTION
- 4기 모집 마감에 따른 모집 노션페이지와 연결되는 버튼을 비활성화 하였습니다.
- 릴리즈 버전을 복구하고, v1.2.0 v1.3.0 v1.4.0 릴리즈로 구분한 태그를 이전 빌드 시점으로 생성해두고, 
각 태그에 맞게 2기 3기 4기 오거나이저를 태그했습니다.